### PR TITLE
fix: `featured` property on userArticles now set to false by default

### DIFF
--- a/server/db/models/UserArticle.js
+++ b/server/db/models/UserArticle.js
@@ -11,7 +11,7 @@ const UserArticle = db.define(
     },
     featured: {
       type: Sequelize.BOOLEAN,
-      allowNull: false,
+      defaultValue: false,
     },
     name: {
       type: Sequelize.TEXT,


### PR DESCRIPTION
# Success conditions:
- [ ] When seeding a database, the `featured` property on `userArticle` should now be set to false unless specifically set to true
- [ ] When seeding, `userArticles` can have a row inserted without defining the `featured` property