### PR TITLE
feat: homepage now accessable via popup

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,5 +6,6 @@
   "action": {
     "default_popup": "popup.html"
   },
+  "homepage_url": "http://localhost:8080",
   "permissions": ["tabs"]
 }


### PR DESCRIPTION
# Success conditions:
While running `npm start:dev`:
- [ ] When you right-click the extension icon, the 'Book-it' item should be click-able
- [ ] Clicking it brings you to the page running on localhost:8080