### PR TITLE
feat: Users now have a one-to-one relationship with authors

### DIFF
--- a/script/seed.js
+++ b/script/seed.js
@@ -56,6 +56,16 @@ async function seed() {
     )}}`,
   }));
 
+  // Creating Cody author relationship
+  await Author.create({
+    name: 'Cody',
+    bio: Faker.lorem.paragraph(),
+    photoUrl: `http://picsum.photos/200/300?random=${Math.floor(
+      Math.random() * 100
+    )}`,
+    userId: knownUsers[0].id,
+  });
+
   // Creating Articles
   const articles = await fakerHelper(100, Article, () => ({
     url: Faker.internet.url(),

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -8,8 +8,8 @@ const Tagging = require('./models/Tagging');
 const Tag = require('./models/Tag');
 const UserArticle = require('./models/UserArticle');
 const Author = require('./models/Author');
-const Sharing = require('./models/Sharing')
-const SharingDetail = require('./models/SharingDetail')
+const Sharing = require('./models/Sharing');
+const SharingDetail = require('./models/SharingDetail');
 
 //associations could go here!
 User.hasMany(UserArticle, { foreignKey: 'userId' });
@@ -28,14 +28,16 @@ Author.belongsToMany(Article, { through: 'credits' });
 Article.belongsToMany(Author, { through: 'credits' });
 
 User.hasMany(Sharing, { foreignKey: 'userId' });
-Sharing.belongsTo(User,{ foreignKey: 'userId' });
+Sharing.belongsTo(User, { foreignKey: 'userId' });
 
 Sharing.hasMany(SharingDetail, { foreignKey: 'sharingId' });
-SharingDetail.belongsTo(Sharing, { foreignKey: 'sharingId' })
+SharingDetail.belongsTo(Sharing, { foreignKey: 'sharingId' });
 
 UserArticle.hasMany(SharingDetail, { foreignKey: 'userArticlesId' });
 SharingDetail.belongsTo(UserArticle, { foreignKey: 'userArticlesId' });
 
+User.hasOne(Author);
+Author.belongsTo(User);
 
 module.exports = {
   db,
@@ -47,6 +49,6 @@ module.exports = {
     UserArticle,
     Author,
     Sharing,
-    SharingDetail
+    SharingDetail,
   },
 };


### PR DESCRIPTION
Users can now be labeled as an 'author' within the database

# Success conditions:
- [ ] Seeding does not throw any errors (Authors do not need to be users, and users don't need to be authors)
- [ ] Cody is associated with the author 'Cody' when seeded